### PR TITLE
Fixing long voice chat delay while speaking

### DIFF
--- a/cfg/ultimateconfig/config_custom.cfg
+++ b/cfg/ultimateconfig/config_custom.cfg
@@ -103,6 +103,11 @@
 // alias "-quickpilleat"							"-attack; slot1"
 // bind "MOUSE4"									"+quickpilleat"
 
+//# Fixing long voice chat delay on high FPS
+// alias "+voicerecordfix"                          "+voicerecord; fps_max 30"                  //# Fixing long voice delay while speaking, especially on high ping
+// alias "-voicerecordfix"                          "-voicerecord; fps_max 300"                 //# Fixing long voice delay while speaking, especially on high ping
+// bind "C"                                         "+voicerecordfix"
+
 //# Print bonus and tank/current information after pressing TAB
 //#
 // alias "+showscores_custom"						"+showscores; net_graph 4"								//# Change net_graph to 0 if you do not want to display net_graph


### PR DESCRIPTION
Having conducted tests, it turned out that at high FPS - Voice chat in the game goes with a big delay, which can be disastrous for the game